### PR TITLE
added srv support and test case with and without srv

### DIFF
--- a/mongoose/mongoose_test.go
+++ b/mongoose/mongoose_test.go
@@ -1,0 +1,47 @@
+package mongoose
+
+import (
+	"fmt"
+	"testing"
+)
+
+const defaultPort = 27017
+
+func TestURLNoSRV(t *testing.T) {
+	dbInfo := DBConnection{
+		Host:     "testHost",
+		Port:     0,
+		Database: "testDatabase",
+		User:     "testUser",
+		Password: "testPassword",
+	}
+	InitiateDB(dbInfo)
+	expectedURL := fmt.Sprintf("mongodb://%s:%s@%s:%d", dbInfo.User, dbInfo.Password, dbInfo.Host, defaultPort)
+	if connectionURL != expectedURL {
+		t.Errorf(`
+		expected -- %s
+		actual ---- %s
+		`, expectedURL, connectionURL)
+		t.Fail()
+	}
+}
+
+func TestURLSRV(t *testing.T) {
+	dbInfo := DBConnection{
+		Host:     "testHost",
+		Port:     0,
+		Database: "testDatabase",
+		User:     "testUser",
+		Password: "testPassword",
+		SRV:      true,
+	}
+	InitiateDB(dbInfo)
+	expectedURL := fmt.Sprintf("mongodb+srv://%s:%s@%s", dbInfo.User, dbInfo.Password, dbInfo.Host)
+	if connectionURL != expectedURL {
+		t.Errorf(`
+		expected -- %s
+		actual ---- %s
+		`, expectedURL, connectionURL)
+		t.Fail()
+	}
+}


### PR DESCRIPTION
Added SRV support as described in the [MongoDB Documentation](https://www.mongodb.com/docs/manual/reference/connection-string/#dns-seed-list-connection-format).
> Also added a test case checking the `connectionURL`.